### PR TITLE
Updated to support XCode installed via the App Store

### DIFF
--- a/Utilities/appcrush/appcrush.rb
+++ b/Utilities/appcrush/appcrush.rb
@@ -37,7 +37,16 @@
 
 # Only pngcrush in 3.2 and above supports revert-iphone-optimizations
 # See http://developer.apple.com/library/ios/#qa/qa2010/qa1681.html
-pngcrush = '/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/pngcrush'
+
+pngcrush = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/pngcrush'
+
+if !File.file?(pngcrush)
+  pngcrush = '/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/pngcrush'
+end
+
+if !File.file?(pngcrush)
+  abort('Unable to find pngcrush')
+end
 
 destination = File.join(ENV['HOME'], 'Desktop')
 


### PR DESCRIPTION
Installing XCode using the App Store places it in /Applications by default, meaning pngcrush will be located there. The script now looks first in /Applications (since that location is more likely to be recent), then /Developer, and fails if it cannot find it.
